### PR TITLE
Remove hard requirement for numeric, auto-incrementing IDs

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -43,7 +43,7 @@ All dates MUST be stored in the ISO 8601 format. Any dates provided in any value
 
 Users, conferences, channels and messages are objects.
 
-Every object MUST have a numerical ID, which allows it to be quickly located and accessed. These numerical IDs MUST begin at the value of 0, and increase upon every registered object. Object IDs MUST NOT overlap. You **cannot** change an object's ID once it's been assigned.
+Every object MUST have a unique ID, which allows it to be quickly located and accessed. Object IDs MUST NOT overlap. You **cannot** change an object's ID once it's been assigned.
 
 Information about IDs can be accessed through
 


### PR DESCRIPTION
Requiring numeric, auto-incrementing IDs may result in data locking, race conditions, and sharding issues. This is unlikely to be an immediate issue, but when an instance gets big enough to warrant distributing its servers across a variety of data centers that will become impossible with an auto-incrementing object identifier system.

I propose we loosen the specification to:

- Allow object IDs to be of any type _and_
- Decouple the responsibility for ordering from the responsibility for efficient lookup.

This will allow implementations to choose between auto-incrementing primary keys or other mechanisms for ID uniqueness and message ordering, such as cursors or timestamps.